### PR TITLE
docs(readme): remove redundant H1 above logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# claude-pal
-
 <p align="center">
   <img src=".github/icon.png" width="600" alt="claude-pal">
 </p>


### PR DESCRIPTION
## Summary
- Remove the `# claude-pal` H1 above the logo image — the logo already serves as the visual title, so the heading was redundant.

Follow-up to #5.

## Test plan
- [ ] Visually confirm rendered README on GitHub shows only the centered logo at the top, with badges directly below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)