### PR TITLE
docs(readme): move disclaimer under tagline as blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Local agent dispatch via a Claude Code plugin. Ships fresh Claude Code containers against GitHub issues with a gated plan → implement → review pipeline.
 
+> **Independent, community-built project.** Not affiliated with, endorsed by, or sponsored by Anthropic, PBC. "Claude" and "Claude Code" are trademarks of Anthropic; this project uses Claude Code as its underlying agent and references these trademarks solely to describe that functionality.
+
 See `docs/superpowers/specs/2026-04-18-claude-pal-design.md` for the design document.
 
 **Status:** early development, v0.x. Not yet usable.
@@ -91,7 +93,3 @@ To report a security issue, see [`SECURITY.md`](SECURITY.md).
 ## License
 
 claude-pal is released under the [MIT License](LICENSE).
-
-## Disclaimer
-
-Independent, community-built project. Not affiliated with, endorsed by, or sponsored by Anthropic, PBC. "Claude" and "Claude Code" are trademarks of Anthropic; this project uses Claude Code as its underlying agent and references these trademarks solely to describe that functionality.


### PR DESCRIPTION
## Summary
- Relocates the trademark/affiliation disclaimer from the bottom of the README to directly under the tagline, styled as a blockquote.
- Matches the placement and formatting used in the sibling `claude-pal-action` README.

## Test plan
- [ ] Confirm the disclaimer renders as a blockquote immediately under the tagline on GitHub.
- [ ] Confirm no duplicate disclaimer remains at the bottom of the README.