### PR TITLE
Distribute claude-pal via self-hosted plugin marketplace (#19)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,9 @@
 {
   "name": "claude-pal",
   "owner": { "name": "jnurre64" },
+  "metadata": {
+    "description": "Self-hosted marketplace for claude-pal — a Claude Code plugin that dispatches agent runs against GitHub issues inside a long-running Docker workspace container."
+  },
   "plugins": [
     {
       "name": "claude-pal",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-pal",
+  "owner": { "name": "jnurre64" },
+  "plugins": [
+    {
+      "name": "claude-pal",
+      "source": {
+        "source": "github",
+        "repo": "jnurre64/claude-pal",
+        "ref": "main"
+      },
+      "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside a long-running Docker workspace container.",
+      "homepage": "https://github.com/jnurre64/claude-pal",
+      "category": "automation"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "source": {
         "source": "github",
         "repo": "jnurre64/claude-pal",
-        "ref": "main"
+        "ref": "v0.5.0"
       },
       "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside a long-running Docker workspace container.",
       "homepage": "https://github.com/jnurre64/claude-pal",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-pal",
-  "version": "0.4.0",
-  "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside an ephemeral Docker container.",
+  "version": "0.5.0",
+  "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside a long-running Docker workspace container.",
   "author": { "name": "jnurre64" },
   "repository": "https://github.com/jnurre64/claude-pal",
   "license": "MIT",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
         run: |
           shellcheck $(find . -name '*.sh' -not -path '*/bats/*' -not -path '*/.git/*')
 
+  marketplace-json:
+    name: marketplace.json parses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate .claude-plugin/marketplace.json with jq
+        run: jq -e . .claude-plugin/marketplace.json > /dev/null
+      - name: Validate .claude-plugin/plugin.json with jq
+        run: jq -e . .claude-plugin/plugin.json > /dev/null
+
   bats:
     name: bats
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.5.0] — 2026-04-21
+## [0.5.0] — 2026-04-23
 
 ### Changed
 - **BREAKING (pre-1.0):** Ephemeral `docker run --rm` + `CLAUDE_CODE_OAUTH_TOKEN` env-passthrough replaced by a long-running workspace container (`claude-pal-workspace`) with in-container `/login`. See `docs/authentication.md`.
@@ -8,8 +8,15 @@
 - Per-run host → container memory sync (`~/.claude/projects/<slug>/memory/` → workspace). Markdown only; `*.jsonl` excluded by default (secret-tier).
 - Container-scoped `CLAUDE.md` via `~/.config/claude-pal/container-CLAUDE.md`; synced per run.
 - New optional knobs: `PAL_CPUS`, `PAL_MEMORY`, `PAL_SYNC_MEMORIES`, `PAL_SYNC_TRANSCRIPTS`.
+- `/pal-setup` now auto-builds `claude-pal:latest` if absent, using `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile` as the build context. The marketplace install flow no longer requires a repo clone for the image build.
+- `docs/install.md` rewritten around the marketplace install flow; clone-based workflow moved to a "Contributor / local dev loop" section.
+- `README.md` "Getting started" and "One-time setup" rewritten for the marketplace install.
 
 ### Added
+- **Plugin marketplace distribution.** Install with `/plugin marketplace add jnurre64/claude-pal` + `/plugin install claude-pal@claude-pal`, replacing the session-scoped `claude --plugin-dir` recipe.
+- `.claude-plugin/marketplace.json` (flat layout, single plugin entry pinned to the release tag).
+- `lib/image.sh` with `pal_image_exists` / `pal_image_build` / `pal_image_ensure` helpers (called by `/pal-setup`).
+- CI: `jq -e` parse check for both `.claude-plugin/*.json` manifests.
 - `/pal-workspace` (start | stop | restart | status | edit-rules).
 - `/pal-login`, `/pal-logout`.
 - `docs/authentication.md`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Claude credentials live in a Docker-managed named volume inside the workspace â€
 
 ## Getting started
 
-See [`docs/install.md`](docs/install.md).
+```
+/plugin marketplace add jnurre64/claude-pal
+/plugin install claude-pal@claude-pal
+/claude-pal:pal-setup
+/claude-pal:pal-login
+```
+
+Full walkthrough in [`docs/install.md`](docs/install.md).
 
 ## Relationship to `claude-pal-action`
 
@@ -46,17 +53,20 @@ Only `GH_TOKEN` lives in your host shell.
 
 ### One-time setup
 
-```bash
-# 1. GitHub PAT (fine-grained, Contents + Pull requests + Issues read/write)
-export GH_TOKEN=github_pat_<token>   # add to ~/.bashrc or ~/.zshrc
-
-# 2. Pull (or build) the image
-docker pull claude-pal:latest
-
-# 3. Start the workspace and mint Claude credentials
-/pal-setup     # creates the named volume + workspace container
-/pal-login     # interactive browser flow, run once per workspace lifetime
-```
+1. Export `GH_TOKEN` in your shell (add to `~/.bashrc` or `~/.zshrc`):
+   ```bash
+   export GH_TOKEN=github_pat_<token>
+   ```
+2. Install the plugin from the marketplace (from any `claude` session):
+   ```
+   /plugin marketplace add jnurre64/claude-pal
+   /plugin install claude-pal@claude-pal
+   ```
+3. Provision the workspace and credentials:
+   ```
+   /claude-pal:pal-setup     # builds the image if absent; creates the workspace
+   /claude-pal:pal-login     # interactive browser flow, run once per workspace lifetime
+   ```
 
 ### Resource caps (optional)
 

--- a/commands/pal-setup.md
+++ b/commands/pal-setup.md
@@ -8,13 +8,28 @@ Guided, one-time setup for claude-pal.
 
 Walk the user through:
 
-1. Verify `docker` is on PATH and reachable.
+1. Verify `docker` is on PATH and reachable (`docker info` succeeds).
 2. Verify `GH_TOKEN` (or `GITHUB_TOKEN`) is exported in the shell. If missing,
    instruct:
+
        echo 'export GH_TOKEN=github_pat_<token>' >> ~/.bashrc
        source ~/.bashrc
+
    The PAT needs `Contents`, `Pull requests`, `Issues` (read/write) on target repos.
-3. `docker pull claude-pal:latest`  (or build locally from `image/`).
+3. Ensure the `claude-pal:latest` image is present. Source the helper and call
+   `pal_image_ensure`:
+
+       . "${CLAUDE_PLUGIN_ROOT}/lib/image.sh"
+       pal_image_ensure
+
+   - If the image is already present, this is a no-op.
+   - If it is absent, `pal_image_ensure` runs `docker build` against
+     `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile` with the plugin root as the
+     build context (equivalent to `./scripts/build-image.sh` from a clone).
+     Before running, tell the user what will happen and wait for confirmation;
+     the build takes a few minutes the first time.
+   - If the build fails, surface the `docker build` output verbatim — do not
+     retry silently.
 4. Run `/pal-workspace start` — creates the named volume and the long-running
    workspace container.
 5. Run `/pal-login` — mints Claude credentials inside the workspace (one-time
@@ -24,6 +39,7 @@ Walk the user through:
    `~/.config/claude-pal/container-CLAUDE.md` that will be synced into the
    container on every run. Use it for container-scoped behavior rules.
 7. (Optional) create `~/.config/claude-pal/config.env` with non-secret knobs:
+
        PAL_CPUS=2.0
        PAL_MEMORY=4g
        PAL_SYNC_MEMORIES=true

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,29 +20,9 @@ claude-pal is a Claude Code plugin that manages a long-running Docker workspace 
 
 ## Install steps
 
-### 1. Clone the repo
+### 1. Export `GH_TOKEN` in your shell profile
 
-```bash
-git clone https://github.com/jnurre64/claude-pal.git ~/repos/claude-pal
-cd ~/repos/claude-pal
-```
-
-### 2. Build (or pull) the container image
-
-```bash
-./scripts/build-image.sh
-# → builds claude-pal:latest on your local Docker daemon
-```
-
-Verify:
-
-```bash
-docker images claude-pal
-```
-
-### 3. Export `GH_TOKEN` in your shell profile
-
-claude-pal only needs **one** host env var: `GH_TOKEN`. Claude credentials live inside the workspace container (step 5) — they are never exported from your shell.
+claude-pal only needs **one** host env var: `GH_TOKEN`. Claude credentials live inside the workspace container (step 3) — they are never exported from your shell.
 
 Create a fine-grained GitHub PAT at https://github.com/settings/personal-access-tokens. Grant repository access for each repo you plan to dispatch against, with these scopes:
 
@@ -68,36 +48,36 @@ Save, then `source ~/.bashrc` in any shell that needs the new value.
 
 > **Do not** set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` in your shell — the workspace-container model does not use them. If you have them set from an earlier claude-pal install, `unset` them and remove them from your rc files. See [`docs/authentication.md`](authentication.md) for the full rationale.
 
-### 4. Load claude-pal as a Claude Code plugin
+### 2. Install the Claude Code plugin from the marketplace
 
-claude-pal is a Claude Code plugin (manifest at `.claude-plugin/plugin.json`, shared libs at plugin-root `lib/`, skills under `skills/pal-*/SKILL.md`, commands under `commands/*.md`). It must be loaded *as a plugin* so `${CLAUDE_PLUGIN_ROOT}` is populated — do NOT copy `skills/pal-*` into `~/.claude/skills/`; the `lib/` sourcing inside each SKILL.md will fail.
+From any `claude` session:
 
-**Developer / local-only (recommended today):**
-
-```bash
-# Validate the manifest (fast, no session needed)
-claude plugin validate ~/repos/claude-pal
-# → "✔ Validation passed"
-
-# Load for one session at a time
-claude --plugin-dir ~/repos/claude-pal
+```
+/plugin marketplace add jnurre64/claude-pal
+/plugin install claude-pal@claude-pal
 ```
 
-`--plugin-dir` is scoped to the one `claude` session. Inside that session, `/plugin` lists `claude-pal` and `/skills` lists the `pal-*` skills. Persistent / marketplace install is out of scope for v0.x.
+Claude Code pulls the repo into its plugin cache and persists the install across sessions. Verify:
 
-### 5. Create the workspace and log in
+```
+/plugin          # should show claude-pal as loaded
+/skills          # should list pal-plan, pal-implement, pal-workspace, pal-login, pal-logout, etc.
+```
 
-Inside a `claude --plugin-dir ~/repos/claude-pal` session:
+### 3. Create the workspace, build the image, and log in
+
+In the same session:
 
 ```
 /claude-pal:pal-setup
-# → verifies Docker + GH_TOKEN + image
-# → creates the `claude-pal-claude` named volume
-# → starts the `claude-pal-workspace` container
+```
 
+`pal-setup` verifies Docker + `GH_TOKEN`, then ensures the `claude-pal:latest` image exists. The first time you run it, `pal-setup` will offer to build the image (a few minutes; `docker build` against the Dockerfile inside the cached plugin). Subsequent runs are no-ops for the image step.
+
+```
 /claude-pal:pal-login
 # → opens a browser to authorize Claude inside the workspace
-# → writes /home/agent/.claude/.credentials.json into the named volume
+# → writes /home/agent/.claude/.credentials.json into the `claude-pal-claude` named volume
 # → one-time, persists for the workspace's lifetime
 ```
 
@@ -114,28 +94,10 @@ docker volume inspect claude-pal-claude
 docker exec claude-pal-workspace ls -la /home/agent/.claude/
 ```
 
-### 6. Verify
-
-Inside the `claude --plugin-dir ~/repos/claude-pal` session:
+### 4. First live dispatch (validate end-to-end)
 
 ```
-/plugin          # should show claude-pal as loaded
-/skills          # should list pal-plan, pal-implement, pal-workspace, pal-login, pal-logout, etc.
-```
-
-From the host shell:
-
-```bash
-docker info                           # should succeed
-[ -n "$GH_TOKEN" ] && echo "gh cred: ok"
-GH_TOKEN="$GH_TOKEN" gh auth status   # should succeed
-docker ps --filter name=claude-pal-workspace   # should show the workspace running
-```
-
-### 7. First live dispatch (validate end-to-end)
-
-```
-# Inside the claude --plugin-dir session, from a checkout of a GitHub repo the PAT can access:
+# From a checkout of a GitHub repo the PAT can access:
 /claude-pal:pal-plan
 # → publishes the most recent docs/superpowers/plans/*.md file as a new issue
 # → prints the issue URL
@@ -175,3 +137,27 @@ v0.x ships the core flow (plan → implement → PR) in sync mode, plus the work
 
 - Async mode + `/claude-pal:pal-status`, `/claude-pal:pal-logs`, `/claude-pal:pal-cancel`
 - Expanded `/claude-pal:pal-revise` coverage for PR-review follow-ups
+
+## Contributor / local dev loop
+
+If you're developing against a clone of the repo (sending PRs, iterating on skills), the marketplace install is not what you want — use the session-scoped `--plugin-dir` instead so you can edit files and see changes immediately.
+
+```bash
+# Clone
+git clone https://github.com/jnurre64/claude-pal.git ~/repos/claude-pal
+cd ~/repos/claude-pal
+
+# Validate the manifest (fast, no session needed)
+claude plugin validate ~/repos/claude-pal
+# → "✔ Validation passed"
+
+# Build the image directly (the marketplace flow does this via /pal-setup;
+# contributors often want to iterate on the Dockerfile without going through
+# the skill each time)
+./scripts/build-image.sh
+
+# Load the plugin for one session
+claude --plugin-dir ~/repos/claude-pal
+```
+
+`--plugin-dir` is scoped to that single `claude` session. Contributors typically have the marketplace install removed (`/plugin marketplace remove claude-pal`) while iterating, to avoid two loaded copies of the plugin fighting over skill names.

--- a/docs/superpowers/plans/2026-04-23-plugin-marketplace.md
+++ b/docs/superpowers/plans/2026-04-23-plugin-marketplace.md
@@ -943,12 +943,22 @@ Edit `.claude-plugin/plugin.json`:
 }
 ```
 
-- [ ] **Step 3: Set `marketplace.json.plugins[0].ref` to the target tag**
+- [ ] **Step 3: Set `marketplace.json.plugins[0].source.ref` to the target tag**
 
-Edit `.claude-plugin/marketplace.json`:
+Edit `.claude-plugin/marketplace.json` — the `ref` lives INSIDE the `source` object (the Claude Code validator rejects top-level `ref` on plugin entries):
 
 ```json
-    "ref": "<TAG>"
+  "plugins": [
+    {
+      "name": "claude-pal",
+      "source": {
+        "source": "github",
+        "repo": "jnurre64/claude-pal",
+        "ref": "<TAG>"
+      },
+      ...
+    }
+  ]
 ```
 
 - [ ] **Step 4: Validate both files**

--- a/docs/superpowers/plans/2026-04-23-plugin-marketplace.md
+++ b/docs/superpowers/plans/2026-04-23-plugin-marketplace.md
@@ -1,0 +1,1113 @@
+# Plugin Marketplace Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish claude-pal as a self-hosted Claude Code plugin marketplace at `jnurre64/claude-pal` so end-users install it with `/plugin marketplace add jnurre64/claude-pal` + `/plugin install claude-pal@claude-pal` instead of cloning and using session-scoped `--plugin-dir`.
+
+**Architecture:** Add `.claude-plugin/marketplace.json` next to the existing `plugin.json` with a single flat plugin entry (`source: "./"`). Move the image-build step out of the user-facing docs and into `/pal-setup` so the marketplace install flow does not require a repo clone. Contributor clone-and-`--plugin-dir` workflow stays, documented separately. Release follows Model A: pin `marketplace.json` `ref` to the latest tag and bump per release.
+
+**Tech Stack:** Bash + shellcheck + BATS-Core (existing test toolchain), Docker (for image-build path), `jq` (for CI JSON validation), Claude Code plugin manifest schema.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md`
+**Issue:** [#19](https://github.com/jnurre64/claude-pal/issues/19)
+
+---
+
+## File Structure
+
+**Create:**
+- `.claude-plugin/marketplace.json` — marketplace manifest (flat, single plugin entry)
+- `lib/image.sh` — image presence-check and build logic, sourced by `/pal-setup`
+- `tests/test_image.bats` — BATS tests for `lib/image.sh` using the `fake-docker.sh` shim
+
+**Modify:**
+- `commands/pal-setup.md` — incorporate the image-ensure step (replacing the `docker pull claude-pal:latest (or build locally from image/)` guidance)
+- `docs/install.md` — rewrite "Install steps" for marketplace flow; move clone-based workflow into a "Contributor / local dev loop" section at the end
+- `README.md` — update "Getting started" one-liner and the "One-time setup" block
+- `tests/test_helper/fake-docker.sh` — extend the shim to distinguish `docker image inspect` from container `inspect`, and to record `docker build` calls
+- `.github/workflows/ci.yml` — add a cheap `jq` parse-check for `.claude-plugin/marketplace.json`
+
+**Not touched in this plan:**
+- `.claude-plugin/plugin.json` — its `version` field will bump in the final release task (separate commit), not during feature work
+- `scripts/build-image.sh` — kept as the contributor / CI entry point; unchanged
+- `image/Dockerfile` — no changes
+
+---
+
+## Task 1: Extend `fake-docker.sh` to support `docker image inspect` and record `docker build`
+
+The existing shim routes everything whose first arg is `inspect` through container-inspect semantics and silently succeeds on `docker build`. The new `pal_image_exists` / `pal_image_build` functions need distinct observables: image-exists state separate from container-exists state, and a way for tests to assert `docker build` was invoked with the right flags.
+
+**Files:**
+- Modify: `tests/test_helper/fake-docker.sh`
+
+- [ ] **Step 1: Read the current shim structure**
+
+Re-read `tests/test_helper/fake-docker.sh` lines 14-70 to confirm the `case "$1" in` layout before editing. The key insight: `docker image inspect foo:latest` has `$1 == "image"`, so it needs a new top-level case branch (not a nested match under `inspect`).
+
+- [ ] **Step 2: Write the failing test (anchor for the new shim behavior)**
+
+Add a new file `tests/test_fake_docker_shim.bats` with:
+
+```bash
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/fake-docker.sh'
+
+setup() { fake_docker_setup; }
+teardown() { fake_docker_teardown; }
+
+@test "fake docker: 'image inspect' fails when image not registered" {
+    run docker image inspect claude-pal:latest
+    assert_failure
+}
+
+@test "fake docker: 'image inspect' succeeds after fake_docker_set_image_exists" {
+    fake_docker_set_image_exists claude-pal:latest
+    run docker image inspect claude-pal:latest
+    assert_success
+}
+
+@test "fake docker: 'build' is recorded in FAKE_DOCKER_LOG" {
+    run docker build -t claude-pal:latest -f some/Dockerfile .
+    assert_success
+    run grep -F "build -t claude-pal:latest" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+./tests/bats/bin/bats tests/test_fake_docker_shim.bats
+```
+
+Expected: all three tests FAIL — `image inspect` currently succeeds unconditionally (routed through the generic `*)` branch), `fake_docker_set_image_exists` is undefined, and `build` is recorded (because of the top-of-shim `echo "$*" >> LOG`) so that third test may already pass; confirm which tests fail before moving on.
+
+- [ ] **Step 4: Update the shim to add `image` handling**
+
+In `tests/test_helper/fake-docker.sh`, inside the `case "$1" in` block (between `inspect)` and `exec)`), add:
+
+```bash
+    image)
+        # Handle `docker image inspect <tag>` — success only if the tag is
+        # marked present via fake_docker_set_image_exists.
+        if [ "${2:-}" = "inspect" ] && [ -n "${3:-}" ]; then
+            if [ -f "$FAKE_DOCKER_STATE/image_${3//:/_}" ]; then
+                echo '[{"Id":"fake"}]'
+                exit 0
+            fi
+            exit 1
+        fi
+        # Any other `docker image <subcommand>` — default success.
+        ;;
+    build)
+        # Already logged at top of shim; default success. Tests grep the log.
+        ;;
+```
+
+The `${3//:/_}` swap maps `claude-pal:latest` to `claude-pal_latest` — a legal filename. The `image_` prefix keeps image-presence markers distinct from `exists` / `running` container markers used elsewhere in the shim. Keep the existing `echo "$*" >> "$FAKE_DOCKER_LOG"` at the top of the shim — it already captures every invocation including `build`.
+
+- [ ] **Step 5: Add the `fake_docker_set_image_exists` / `fake_docker_set_image_absent` helpers**
+
+After the existing `fake_docker_set_absent` function in the shim, add:
+
+```bash
+fake_docker_set_image_exists() {
+    local tag="${1:-claude-pal:latest}"
+    : > "$FAKE_DOCKER_STATE/image_${tag//:/_}"
+}
+
+fake_docker_set_image_absent() {
+    local tag="${1:-claude-pal:latest}"
+    rm -f "$FAKE_DOCKER_STATE/image_${tag//:/_}"
+}
+```
+
+- [ ] **Step 6: Run the tests and confirm they pass**
+
+```bash
+./tests/bats/bin/bats tests/test_fake_docker_shim.bats
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 7: Run the full bats suite to catch regressions**
+
+```bash
+./tests/bats/bin/bats tests/
+```
+
+Expected: all existing tests still pass (the new `image` / `build` case arms don't intersect container-inspect behavior, which other tests rely on).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/test_helper/fake-docker.sh tests/test_fake_docker_shim.bats
+git commit -m "test(fake-docker): add image-inspect and build-call observables"
+```
+
+---
+
+## Task 2: Implement `pal_image_exists` in `lib/image.sh`
+
+Thin wrapper over `docker image inspect`. This is what `pal_image_ensure` (Task 4) will call to decide whether to build.
+
+**Files:**
+- Create: `lib/image.sh`
+- Create: `tests/test_image.bats`
+
+- [ ] **Step 1: Create the test file with a failing test**
+
+Create `tests/test_image.bats`:
+
+```bash
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/fake-docker.sh'
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export CLAUDE_PLUGIN_ROOT="$REPO_ROOT"
+    fake_docker_setup
+    # shellcheck source=../lib/image.sh
+    . "$REPO_ROOT/lib/image.sh"
+}
+
+teardown() {
+    fake_docker_teardown
+}
+
+@test "pal_image_exists: returns success when image is present" {
+    fake_docker_set_image_exists claude-pal:latest
+    run pal_image_exists
+    assert_success
+}
+
+@test "pal_image_exists: returns failure when image is absent" {
+    fake_docker_set_image_absent claude-pal:latest
+    run pal_image_exists
+    assert_failure
+}
+
+@test "pal_image_exists: uses PAL_WORKSPACE_IMAGE override" {
+    fake_docker_set_image_exists claude-pal:v0.5.0
+    PAL_WORKSPACE_IMAGE=claude-pal:v0.5.0 run pal_image_exists
+    assert_success
+}
+```
+
+- [ ] **Step 2: Run the test — it must fail because `lib/image.sh` does not exist yet**
+
+```bash
+./tests/bats/bin/bats tests/test_image.bats
+```
+
+Expected: all three tests FAIL — bats reports that `lib/image.sh` cannot be sourced (no such file).
+
+- [ ] **Step 3: Create `lib/image.sh` with the minimal function**
+
+```bash
+# lib/image.sh
+# shellcheck shell=bash
+# Host-side helpers for the claude-pal container image.
+
+: "${PAL_WORKSPACE_IMAGE:=claude-pal:latest}"
+
+pal_image_exists() {
+    docker image inspect "$PAL_WORKSPACE_IMAGE" >/dev/null 2>&1
+}
+```
+
+The `PAL_WORKSPACE_IMAGE` default matches `lib/workspace.sh`'s default exactly so the two files agree on which image the workspace expects.
+
+- [ ] **Step 4: Run the test again — confirm all three pass**
+
+```bash
+./tests/bats/bin/bats tests/test_image.bats
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 5: Run shellcheck**
+
+```bash
+shellcheck lib/image.sh
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image.sh tests/test_image.bats
+git commit -m "feat(lib): add pal_image_exists check for claude-pal:latest"
+```
+
+---
+
+## Task 3: Implement `pal_image_build` in `lib/image.sh`
+
+Runs `docker build` against the plugin-root Dockerfile. The function does not prompt — it builds unconditionally; the calling skill (Task 5) is responsible for asking the user first.
+
+**Files:**
+- Modify: `lib/image.sh`
+- Modify: `tests/test_image.bats`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `tests/test_image.bats`:
+
+```bash
+@test "pal_image_build: invokes docker build with Dockerfile and plugin root as context" {
+    run pal_image_build
+    assert_success
+    run grep -F -- "-f ${CLAUDE_PLUGIN_ROOT}/image/Dockerfile" "$FAKE_DOCKER_LOG"
+    assert_success
+    run grep -F -- "-t claude-pal:latest" "$FAKE_DOCKER_LOG"
+    assert_success
+    # Build context is the plugin root (trailing positional).
+    run grep -F -- "${CLAUDE_PLUGIN_ROOT}" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_build: passes BASE_IMAGE build-arg (default ubuntu:24.04)" {
+    run pal_image_build
+    assert_success
+    run grep -F -- "--build-arg BASE_IMAGE=ubuntu:24.04" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_build: respects BASE_IMAGE env override" {
+    BASE_IMAGE=ubuntu:22.04 run pal_image_build
+    assert_success
+    run grep -F -- "--build-arg BASE_IMAGE=ubuntu:22.04" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_build: respects PAL_WORKSPACE_IMAGE tag override" {
+    PAL_WORKSPACE_IMAGE=claude-pal:v0.5.0 run pal_image_build
+    assert_success
+    run grep -F -- "-t claude-pal:v0.5.0" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+./tests/bats/bin/bats tests/test_image.bats
+```
+
+Expected: the four new tests FAIL — `pal_image_build` is undefined.
+
+- [ ] **Step 3: Implement `pal_image_build` in `lib/image.sh`**
+
+Append to `lib/image.sh`:
+
+```bash
+pal_image_build() {
+    local base_image="${BASE_IMAGE:-ubuntu:24.04}"
+    docker build \
+        --build-arg BASE_IMAGE="$base_image" \
+        -f "${CLAUDE_PLUGIN_ROOT}/image/Dockerfile" \
+        -t "$PAL_WORKSPACE_IMAGE" \
+        "${CLAUDE_PLUGIN_ROOT}"
+}
+```
+
+This mirrors `scripts/build-image.sh` (which `cd`s into `REPO_ROOT` and runs `docker build -f image/Dockerfile .`) but uses `${CLAUDE_PLUGIN_ROOT}` as the explicit build context so it works identically from a clone or from the marketplace cache.
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+./tests/bats/bin/bats tests/test_image.bats
+```
+
+Expected: all seven tests (3 from Task 2 + 4 from Task 3) PASS.
+
+- [ ] **Step 5: Run shellcheck**
+
+```bash
+shellcheck lib/image.sh
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image.sh tests/test_image.bats
+git commit -m "feat(lib): add pal_image_build using \${CLAUDE_PLUGIN_ROOT}"
+```
+
+---
+
+## Task 4: Implement `pal_image_ensure` in `lib/image.sh`
+
+The compose point: check if the image exists; if not, build it. Single entry point for `/pal-setup`.
+
+**Files:**
+- Modify: `lib/image.sh`
+- Modify: `tests/test_image.bats`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `tests/test_image.bats`:
+
+```bash
+@test "pal_image_ensure: builds when image is absent" {
+    fake_docker_set_image_absent claude-pal:latest
+    run pal_image_ensure
+    assert_success
+    run grep -F "build" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_ensure: does NOT build when image is already present" {
+    fake_docker_set_image_exists claude-pal:latest
+    run pal_image_ensure
+    assert_success
+    run grep -F "build" "$FAKE_DOCKER_LOG"
+    assert_failure
+}
+
+@test "pal_image_ensure: prints progress note when building" {
+    fake_docker_set_image_absent claude-pal:latest
+    run pal_image_ensure
+    assert_success
+    assert_output --partial "pal: building claude-pal:latest"
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+./tests/bats/bin/bats tests/test_image.bats
+```
+
+Expected: the three new tests FAIL — `pal_image_ensure` is undefined.
+
+- [ ] **Step 3: Implement `pal_image_ensure` in `lib/image.sh`**
+
+Append to `lib/image.sh`:
+
+```bash
+pal_image_ensure() {
+    if pal_image_exists; then
+        return 0
+    fi
+    echo "pal: building ${PAL_WORKSPACE_IMAGE}…" >&2
+    pal_image_build
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+./tests/bats/bin/bats tests/test_image.bats
+```
+
+Expected: all 10 tests in `tests/test_image.bats` PASS.
+
+- [ ] **Step 5: Run shellcheck and the full bats suite**
+
+```bash
+shellcheck lib/image.sh
+./tests/bats/bin/bats tests/
+```
+
+Expected: zero shellcheck warnings; all bats tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image.sh tests/test_image.bats
+git commit -m "feat(lib): add pal_image_ensure (build-if-absent compose point)"
+```
+
+---
+
+## Task 5: Wire `pal_image_ensure` into `/pal-setup`
+
+Replace the current step-3 guidance (`docker pull claude-pal:latest (or build locally from image/)`) with a direct call to `pal_image_ensure`. The skill still walks the user through env-var and credentials steps — only the image provisioning changes.
+
+**Files:**
+- Modify: `commands/pal-setup.md`
+
+- [ ] **Step 1: Rewrite the skill body**
+
+Replace the entire current body of `commands/pal-setup.md` (keeping the frontmatter untouched) with:
+
+````markdown
+# /claude-pal:pal-setup
+
+Guided, one-time setup for claude-pal.
+
+Walk the user through:
+
+1. Verify `docker` is on PATH and reachable (`docker info` succeeds).
+2. Verify `GH_TOKEN` (or `GITHUB_TOKEN`) is exported in the shell. If missing,
+   instruct:
+
+       echo 'export GH_TOKEN=github_pat_<token>' >> ~/.bashrc
+       source ~/.bashrc
+
+   The PAT needs `Contents`, `Pull requests`, `Issues` (read/write) on target repos.
+3. Ensure the `claude-pal:latest` image is present. Source the helper and call
+   `pal_image_ensure`:
+
+       . "${CLAUDE_PLUGIN_ROOT}/lib/image.sh"
+       pal_image_ensure
+
+   - If the image is already present, this is a no-op.
+   - If it is absent, `pal_image_ensure` runs `docker build` against
+     `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile` with the plugin root as the
+     build context (equivalent to `./scripts/build-image.sh` from a clone).
+     Before running, tell the user what will happen and wait for confirmation;
+     the build takes a few minutes the first time.
+   - If the build fails, surface the `docker build` output verbatim — do not
+     retry silently.
+4. Run `/pal-workspace start` — creates the named volume and the long-running
+   workspace container.
+5. Run `/pal-login` — mints Claude credentials inside the workspace (one-time
+   interactive browser flow). Credentials persist in the `claude-pal-claude`
+   named volume; they never touch the host filesystem.
+6. (Optional) `/pal-workspace edit-rules` — opens an empty
+   `~/.config/claude-pal/container-CLAUDE.md` that will be synced into the
+   container on every run. Use it for container-scoped behavior rules.
+7. (Optional) create `~/.config/claude-pal/config.env` with non-secret knobs:
+
+       PAL_CPUS=2.0
+       PAL_MEMORY=4g
+       PAL_SYNC_MEMORIES=true
+       PAL_SYNC_TRANSCRIPTS=false
+
+Report back what was verified and what still needs doing.
+````
+
+- [ ] **Step 2: Manually verify the markdown renders and the commands are sensible**
+
+```bash
+cat commands/pal-setup.md
+```
+
+Expected: frontmatter preserved; step 3 references `${CLAUDE_PLUGIN_ROOT}/lib/image.sh` and `pal_image_ensure`; the rest of the steps (4–7) are unchanged from the previous version.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add commands/pal-setup.md
+git commit -m "feat(skill): /pal-setup auto-builds image via pal_image_ensure"
+```
+
+---
+
+## Task 6: Add `.claude-plugin/marketplace.json`
+
+Ships the marketplace manifest. `ref` is set to `"main"` during development; the final release task (Task 11) flips it to the chosen tag before merge.
+
+**Files:**
+- Create: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Create the manifest**
+
+```json
+{
+  "name": "claude-pal",
+  "owner": { "name": "jnurre64" },
+  "plugins": [
+    {
+      "name": "claude-pal",
+      "source": "./",
+      "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside a long-running Docker workspace container.",
+      "homepage": "https://github.com/jnurre64/claude-pal",
+      "category": "automation",
+      "ref": "main"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Verify JSON parses cleanly**
+
+```bash
+jq . .claude-plugin/marketplace.json
+```
+
+Expected: the manifest echoed back formatted; exit code 0.
+
+- [ ] **Step 3: Validate via Claude Code's plugin validator**
+
+```bash
+claude plugin validate .
+```
+
+Expected: `✔ Validation passed` (the validator recognises both `plugin.json` and `marketplace.json`). If the validator reports a schema error for `marketplace.json`, that is a real bug — fix before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "feat(plugin): add .claude-plugin/marketplace.json"
+```
+
+---
+
+## Task 7: Add `jq` parse check for `marketplace.json` to CI
+
+Cheap guard against a future edit corrupting the JSON. Runs in the existing `bats` job (which already `apt-get`s nothing extra — `jq` is preinstalled on `ubuntu-latest`).
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a new job to `.github/workflows/ci.yml`**
+
+Insert before the `bats:` job (so it runs in parallel with shellcheck and bats):
+
+```yaml
+  marketplace-json:
+    name: marketplace.json parses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate .claude-plugin/marketplace.json with jq
+        run: jq -e . .claude-plugin/marketplace.json > /dev/null
+      - name: Validate .claude-plugin/plugin.json with jq
+        run: jq -e . .claude-plugin/plugin.json > /dev/null
+```
+
+`jq -e` makes jq exit non-zero if the filter produces a false or null value — here it doubles as a structural sanity check (no accidental `null` document).
+
+- [ ] **Step 2: Run the parse locally to mirror what CI will do**
+
+```bash
+jq -e . .claude-plugin/marketplace.json > /dev/null
+jq -e . .claude-plugin/plugin.json > /dev/null
+echo "exit: $?"
+```
+
+Expected: `exit: 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add jq parse check for .claude-plugin/*.json"
+```
+
+---
+
+## Task 8: Rewrite `docs/install.md` for the marketplace flow
+
+Main install path moves to marketplace install; clone-based workflow becomes the "Contributor / local dev loop" section at the bottom.
+
+**Files:**
+- Modify: `docs/install.md`
+
+- [ ] **Step 1: Replace lines 21–124 (the `## Install steps` block) with the new marketplace-first flow**
+
+Replace from `## Install steps` through the end of step 7 ("### 7. First live dispatch …") with:
+
+````markdown
+## Install steps
+
+### 1. Export `GH_TOKEN` in your shell profile
+
+claude-pal only needs **one** host env var: `GH_TOKEN`. Claude credentials live inside the workspace container (step 3) — they are never exported from your shell.
+
+Create a fine-grained GitHub PAT at https://github.com/settings/personal-access-tokens. Grant repository access for each repo you plan to dispatch against, with these scopes:
+
+- Contents: read and write
+- Pull requests: read and write
+- Issues: read and write
+- Metadata: read
+
+Append to `~/.bashrc` (or `~/.zshrc`):
+
+```bash
+# claude-pal
+export GH_TOKEN=github_pat_...your-PAT...
+```
+
+Save, then `source ~/.bashrc` in any shell that needs the new value.
+
+**Windows (PowerShell, persistent for the current user):**
+```powershell
+[System.Environment]::SetEnvironmentVariable('GH_TOKEN', 'github_pat_...', 'User')
+# Open a new PowerShell / Git Bash to pick up the new env
+```
+
+> **Do not** set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` in your shell — the workspace-container model does not use them. If you have them set from an earlier claude-pal install, `unset` them and remove them from your rc files. See [`docs/authentication.md`](authentication.md) for the full rationale.
+
+### 2. Install the Claude Code plugin from the marketplace
+
+From any `claude` session:
+
+```
+/plugin marketplace add jnurre64/claude-pal
+/plugin install claude-pal@claude-pal
+```
+
+Claude Code pulls the repo into its plugin cache and persists the install across sessions. Verify:
+
+```
+/plugin          # should show claude-pal as loaded
+/skills          # should list pal-plan, pal-implement, pal-workspace, pal-login, pal-logout, etc.
+```
+
+### 3. Create the workspace, build the image, and log in
+
+In the same session:
+
+```
+/claude-pal:pal-setup
+```
+
+`pal-setup` verifies Docker + `GH_TOKEN`, then ensures the `claude-pal:latest` image exists. The first time you run it, `pal-setup` will offer to build the image (a few minutes; `docker build` against the Dockerfile inside the cached plugin). Subsequent runs are no-ops for the image step.
+
+```
+/claude-pal:pal-login
+# → opens a browser to authorize Claude inside the workspace
+# → writes /home/agent/.claude/.credentials.json into the `claude-pal-claude` named volume
+# → one-time, persists for the workspace's lifetime
+```
+
+Verify:
+
+```
+/claude-pal:pal-workspace status
+```
+
+From the host shell you can inspect the volume:
+
+```bash
+docker volume inspect claude-pal-claude
+docker exec claude-pal-workspace ls -la /home/agent/.claude/
+```
+
+### 4. First live dispatch (validate end-to-end)
+
+```
+# From a checkout of a GitHub repo the PAT can access:
+/claude-pal:pal-plan
+# → publishes the most recent docs/superpowers/plans/*.md file as a new issue
+# → prints the issue URL
+
+/claude-pal:pal-implement <the-issue-number>
+# → runs preflight checks
+# → docker execs the pipeline inside the workspace (adversarial review → TDD → post-impl review → PR)
+# → prints the PR URL on success
+```
+
+Watch for errors at each stage. Common failures are covered below.
+````
+
+- [ ] **Step 2: Append the "Contributor / local dev loop" section to the bottom of `docs/install.md`**
+
+After the existing "What's not in this release" section (or at the very end of the file if you prefer), add:
+
+````markdown
+## Contributor / local dev loop
+
+If you're developing against a clone of the repo (sending PRs, iterating on skills), the marketplace install is not what you want — use the session-scoped `--plugin-dir` instead so you can edit files and see changes immediately.
+
+```bash
+# Clone
+git clone https://github.com/jnurre64/claude-pal.git ~/repos/claude-pal
+cd ~/repos/claude-pal
+
+# Validate the manifest (fast, no session needed)
+claude plugin validate ~/repos/claude-pal
+# → "✔ Validation passed"
+
+# Build the image directly (the marketplace flow does this via /pal-setup;
+# contributors often want to iterate on the Dockerfile without going through
+# the skill each time)
+./scripts/build-image.sh
+
+# Load the plugin for one session
+claude --plugin-dir ~/repos/claude-pal
+```
+
+`--plugin-dir` is scoped to that single `claude` session. Contributors typically have the marketplace install removed (`/plugin marketplace remove claude-pal`) while iterating, to avoid two loaded copies of the plugin fighting over skill names.
+````
+
+- [ ] **Step 3: Proofread the file**
+
+```bash
+less docs/install.md
+```
+
+Check: step numbering runs 1 → 4 (not 1-2-then-4), all internal links resolve, the troubleshooting table mentions `/claude-pal:pal-workspace` not the old clone path, and the contributor section appears at the end.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/install.md
+git commit -m "docs(install): marketplace-first install flow; clone moved to contributor section"
+```
+
+---
+
+## Task 9: Update `README.md` "Getting started" and "One-time setup"
+
+Align the README with the install.md rewrite. Two blocks change; everything else (What it does, Authentication intro, Per-repo config, Plugin skills, Contributing, License) stays.
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Replace the "Getting started" section**
+
+Replace the block at lines 31–33:
+
+```markdown
+## Getting started
+
+See [`docs/install.md`](docs/install.md).
+```
+
+with:
+
+```markdown
+## Getting started
+
+```
+/plugin marketplace add jnurre64/claude-pal
+/plugin install claude-pal@claude-pal
+/claude-pal:pal-setup
+/claude-pal:pal-login
+```
+
+Full walkthrough in [`docs/install.md`](docs/install.md).
+```
+
+- [ ] **Step 2: Replace the "One-time setup" block**
+
+Replace the block at lines 47–59 (the `### One-time setup` fenced block):
+
+```markdown
+### One-time setup
+
+```bash
+# 1. GitHub PAT (fine-grained, Contents + Pull requests + Issues read/write)
+export GH_TOKEN=github_pat_<token>   # add to ~/.bashrc or ~/.zshrc
+
+# 2. Pull (or build) the image
+docker pull claude-pal:latest
+
+# 3. Start the workspace and mint Claude credentials
+/pal-setup     # creates the named volume + workspace container
+/pal-login     # interactive browser flow, run once per workspace lifetime
+```
+```
+
+with:
+
+````markdown
+### One-time setup
+
+1. Export `GH_TOKEN` in your shell (add to `~/.bashrc` or `~/.zshrc`):
+   ```bash
+   export GH_TOKEN=github_pat_<token>
+   ```
+2. Install the plugin from the marketplace (from any `claude` session):
+   ```
+   /plugin marketplace add jnurre64/claude-pal
+   /plugin install claude-pal@claude-pal
+   ```
+3. Provision the workspace and credentials:
+   ```
+   /claude-pal:pal-setup     # builds the image if absent; creates the workspace
+   /claude-pal:pal-login     # interactive browser flow, run once per workspace lifetime
+   ```
+````
+
+- [ ] **Step 3: Proofread**
+
+```bash
+less README.md
+```
+
+Check: both the Getting started block and the One-time setup block reference the marketplace install path; no mention of `docker pull claude-pal:latest` remains in the user-facing flow (it's fine if it survives anywhere else as a historical note — but the One-time setup should not prescribe it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): align Getting started + One-time setup with marketplace flow"
+```
+
+---
+
+## Task 10: Pre-merge local verification
+
+Marketplace install (`/plugin marketplace add jnurre64/claude-pal`) can only be tested *after* the PR merges into `main` — until then the manifest isn't at the URL Claude Code fetches. So this task is the pre-merge gate: manifest validity, full test suite, and (optionally) an end-to-end `/pal-setup` run against a clone via `--plugin-dir`.
+
+**Files:** none changed; verification only.
+
+- [ ] **Step 1: Validate both plugin manifests**
+
+```bash
+jq -e . .claude-plugin/plugin.json > /dev/null
+jq -e . .claude-plugin/marketplace.json > /dev/null
+claude plugin validate .
+```
+
+Expected: all three succeed; `claude plugin validate` reports `✔ Validation passed`.
+
+- [ ] **Step 2: Run shellcheck and the full bats suite**
+
+```bash
+shellcheck $(find . -name '*.sh' -not -path '*/bats/*' -not -path '*/.git/*')
+./tests/bats/bin/bats tests/
+```
+
+Expected: zero shellcheck warnings; every bats test passes (including the new `tests/test_image.bats` and `tests/test_fake_docker_shim.bats`).
+
+- [ ] **Step 3: (Optional) End-to-end `/pal-setup` via `--plugin-dir`**
+
+If you have the spare ~5 minutes for a real `docker build`, exercise the new `/pal-setup` path against a clone:
+
+```bash
+# From a fresh shell (no pre-existing claude-pal:latest image)
+docker rmi claude-pal:latest 2>/dev/null || true
+claude --plugin-dir $PWD
+```
+
+Inside the session: `/claude-pal:pal-setup`. Expect the skill to announce the image is missing, offer to build, and on confirmation run `docker build` against `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile`. Follow through to `/pal-login` + `/pal-workspace status` if you want full end-to-end coverage.
+
+This is optional because the unit tests in `tests/test_image.bats` already cover the decision logic; the real build just catches environment issues (Docker daemon, buildx quirks) that mocks can't.
+
+- [ ] **Step 4: Push the branch and open the PR**
+
+```bash
+git push -u origin local-plugin-marketplace
+GH_TOKEN=$(cat ~/.config/gh-tokens/claude-pal-token) gh pr create \
+  --repo jnurre64/claude-pal \
+  --title "Distribute claude-pal via self-hosted plugin marketplace" \
+  --body "Closes #19.
+
+Spec: \`docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md\`
+Plan: \`docs/superpowers/plans/2026-04-23-plugin-marketplace.md\`
+
+## Summary
+- Add \`.claude-plugin/marketplace.json\` (flat layout, single plugin entry).
+- \`/pal-setup\` auto-builds \`claude-pal:latest\` via new \`lib/image.sh\` helpers (test coverage in \`tests/test_image.bats\`).
+- Rewrite \`docs/install.md\` and \`README.md\` for the marketplace flow; clone-based workflow moves to a contributor section.
+- CI \`jq\` parse check for both plugin manifests.
+
+## Test plan
+- [x] BATS: \`tests/test_image.bats\`, \`tests/test_fake_docker_shim.bats\`
+- [x] shellcheck: clean
+- [x] \`claude plugin validate .\`
+- [ ] Post-merge smoke test on clean \`CLAUDE_CONFIG_DIR\` (Task 12)
+- [ ] Post-tag re-smoke (Task 12)"
+```
+
+Leave the PR open for review. The release commit (Task 11) lands on this same branch before merge.
+
+---
+
+## Task 11: Release commit — bump `plugin.json.version` and set `marketplace.json.ref`
+
+This is the final commit on the feature branch before the PR merges. Version number is picked at this point (per the spec, the number itself is out of scope for issue #19 — just the mechanical step is prescribed).
+
+**Files:**
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Pick the target version**
+
+Decide the tag name. Candidates:
+- `v0.5.0` — aligns with `CHANGELOG.md`'s 2026-04-21 entry, which currently claims 0.5.0 shipped but no tag exists.
+- `v0.6.0` — treat this PR as the 0.6.0 bump (marketplace is a material feature).
+
+Record the choice in the PR description. The rest of this task uses `<TAG>` as a placeholder — substitute the actual value.
+
+- [ ] **Step 2: Bump `plugin.json.version`**
+
+Edit `.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "claude-pal",
+  "version": "<TAG-without-leading-v>",
+  ...
+}
+```
+
+- [ ] **Step 3: Set `marketplace.json.plugins[0].ref` to the target tag**
+
+Edit `.claude-plugin/marketplace.json`:
+
+```json
+    "ref": "<TAG>"
+```
+
+- [ ] **Step 4: Validate both files**
+
+```bash
+jq -e . .claude-plugin/plugin.json > /dev/null
+jq -e . .claude-plugin/marketplace.json > /dev/null
+claude plugin validate .
+```
+
+Expected: all three commands succeed; validator reports `✔ Validation passed`.
+
+- [ ] **Step 5: Add a CHANGELOG entry (if the chosen tag isn't already in the file)**
+
+If the tag is `v0.6.0` (or any tag not yet in `CHANGELOG.md`), prepend a new entry at the top of the `Added` / `Changed` sections:
+
+```markdown
+## [0.6.0] — <today's date>
+
+### Added
+- **Plugin marketplace distribution.** claude-pal can now be installed with
+  `/plugin marketplace add jnurre64/claude-pal` + `/plugin install claude-pal@claude-pal`,
+  replacing the session-scoped `claude --plugin-dir` recipe.
+- `.claude-plugin/marketplace.json` (flat layout, single plugin entry pinned to the release tag).
+- `lib/image.sh` with `pal_image_exists` / `pal_image_build` / `pal_image_ensure`.
+
+### Changed
+- `/pal-setup` now auto-builds `claude-pal:latest` if absent, using
+  `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile`. The marketplace install flow
+  no longer requires a repo clone for the image build.
+- `docs/install.md` rewritten around the marketplace flow; clone workflow
+  moved to a "Contributor / local dev loop" section.
+- `README.md` "Getting started" and "One-time setup" rewritten for the
+  marketplace install.
+```
+
+If the tag is `v0.5.0`, the existing 0.5.0 entry already covers this release cycle — in that case append these bullets to the existing `Added` / `Changed` sections instead of creating a new one. (Ask the maintainer before doing this — adding to a tagged/shipped version is unusual.)
+
+- [ ] **Step 6: Commit the release bundle and push**
+
+```bash
+git add .claude-plugin/plugin.json .claude-plugin/marketplace.json CHANGELOG.md
+git commit -m "chore(release): v<TAG> — plugin marketplace distribution (#19)"
+git push
+```
+
+- [ ] **Step 7: Request review on the PR**
+
+The PR was opened in Task 10 Step 4 and has been accumulating review feedback. This release commit is typically the last before merge. Confirm reviewers are happy; request re-review if needed:
+
+```bash
+GH_TOKEN=$(cat ~/.config/gh-tokens/claude-pal-token) gh pr view --repo jnurre64/claude-pal
+```
+
+---
+
+## Task 12: Post-merge — tag the merge commit, smoke-test, push
+
+After the maintainer merges the PR, the single-PR-one-tag flow closes with `git tag + git push`. `marketplace.json` on `main` now references a tag that exists, and end users can `/plugin marketplace update` to receive it.
+
+**Files:** none changed; git operations only.
+
+- [ ] **Step 1: Pull the merged `main`**
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+- [ ] **Step 2: Verify the merge commit contains the release bundle**
+
+```bash
+jq -r '.version' .claude-plugin/plugin.json
+jq -r '.plugins[0].ref' .claude-plugin/marketplace.json
+```
+
+Expected: the `version` matches `<TAG>` (without `v-`), and the `ref` matches `<TAG>` (with `v-`). If either mismatches, the release commit didn't make it in — investigate before tagging.
+
+- [ ] **Step 3: Tag the merge commit and push**
+
+```bash
+git tag <TAG>
+git push origin <TAG>
+```
+
+This closes the "seconds-long window" the spec warns about — `main`'s `marketplace.json` now references a tag that exists.
+
+- [ ] **Step 4: Create a GitHub release from the tag**
+
+```bash
+GH_TOKEN=$(cat ~/.config/gh-tokens/claude-pal-token) gh release create <TAG> \
+  --repo jnurre64/claude-pal \
+  --title "<TAG> — plugin marketplace distribution" \
+  --notes-from-tag
+```
+
+(If `--notes-from-tag` is unused because the tag is lightweight, pass `--notes-file CHANGELOG.md` or compose inline notes from the CHANGELOG entry added in Task 11 Step 5.)
+
+- [ ] **Step 5: End-to-end smoke test against the published tag**
+
+On a host with `claude` + `docker` installed, but where claude-pal has never been set up:
+
+```bash
+CLAUDE_CONFIG_DIR=$(mktemp -d)
+export CLAUDE_CONFIG_DIR
+export GH_TOKEN=<a valid fine-grained PAT>
+# Optional but recommended for a clean test: remove the image first
+docker rmi claude-pal:latest 2>/dev/null || true
+claude
+```
+
+Inside the session, run each step and verify the expected output:
+
+1. `/plugin marketplace add jnurre64/claude-pal` — expect no errors; "marketplace added".
+2. `/plugin install claude-pal@claude-pal` — expect the plugin to resolve to `<TAG>` (not `main`) and install.
+3. `/plugin` — expect `claude-pal` in the listed plugins; the version column should match `<TAG-without-leading-v>`.
+4. `/skills` — expect `pal-plan`, `pal-implement`, `pal-workspace`, `pal-login`, `pal-logout`, `pal-status`, `pal-logs`, `pal-cancel`, `pal-revise` all listed.
+5. `/claude-pal:pal-setup` — expect the skill to announce the image is missing and offer to build. Confirm; watch `docker build` run to completion (a few minutes the first time).
+6. `/claude-pal:pal-login` — complete the browser flow.
+7. `/claude-pal:pal-workspace status` — expect `workspace: claude-pal-workspace (running)` and `auth: present`.
+
+If any step fails, **do not close issue #19.** Instead: fix the bug on a follow-up branch, re-release with a patch version (e.g. `<TAG>.1`), and re-run this smoke test. The bad tag stays (tags are immutable conventionally); users can bypass by reinstalling or running `/plugin marketplace update`.
+
+- [ ] **Step 6: Cleanup after smoke test**
+
+```bash
+# Inside the smoke-test session or on the host:
+docker stop claude-pal-workspace && docker rm claude-pal-workspace
+docker volume rm claude-pal-claude
+rm -rf "$CLAUDE_CONFIG_DIR"
+```
+
+- [ ] **Step 7: Close issue #19 with a comment linking the release**
+
+```bash
+GH_TOKEN=$(cat ~/.config/gh-tokens/claude-pal-token) gh issue close 19 \
+  --repo jnurre64/claude-pal \
+  --comment "Shipped in <TAG>: https://github.com/jnurre64/claude-pal/releases/tag/<TAG>"
+```
+
+---
+
+## Acceptance criteria
+
+- `.claude-plugin/marketplace.json` exists at repo root, parses cleanly with `jq`, and is recognised by `claude plugin validate`.
+- `lib/image.sh` with three functions (`pal_image_exists`, `pal_image_build`, `pal_image_ensure`) passes shellcheck and has BATS coverage for: image-present short-circuit, image-absent build path, `BASE_IMAGE` override, `PAL_WORKSPACE_IMAGE` override.
+- `commands/pal-setup.md` references `${CLAUDE_PLUGIN_ROOT}/lib/image.sh` and documents the auto-build behavior.
+- `docs/install.md` primary flow starts with `/plugin marketplace add` (no `git clone` step in the main path); a Contributor section at the end preserves the clone workflow.
+- `README.md` "Getting started" and "One-time setup" both reference the marketplace install.
+- CI (`.github/workflows/ci.yml`) runs `jq -e` against both manifest files on every push / PR.
+- Post-merge marketplace smoke test (Task 12 Step 5) passes on a clean `CLAUDE_CONFIG_DIR`: `/plugin marketplace add` → `/plugin install` → `/pal-setup` → `/pal-login` → `/pal-workspace status` all succeed.
+- `https://github.com/jnurre64/claude-pal/releases/tag/<TAG>` exists and issue #19 is closed with a link to the release.
+
+---
+
+## Non-goals (do not add these tasks)
+
+- **Prebuilt container image publication to GHCR.** Tracked in #18.
+- **CI automation of `marketplace.json` `ref` bumping.** Manual for v1 per the spec.
+- **Icon in the marketplace entry.** Requires binary-path decisions out of scope here.
+- **Changing the repo layout from flat to nested.** Revisit only if a second plugin is ever added.
+- **Publishing to the `claude-plugins-official` marketplace.** Separate effort; not part of the self-hosted marketplace work.

--- a/docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md
@@ -80,6 +80,32 @@ There is a seconds-long window between PR merge and tag push where `main`'s `mar
 
 Rejected alternative: a two-phase approach (land marketplace.json first with `ref: "v0.4.0"` as a placeholder, cut the real tag later) was considered and rejected. `v0.4.0` predates the workspace-container rework and would give any interim installer a broken build.
 
+## `/pal-setup` skill changes
+
+Issue #19 states: *"`/pal-setup` continues to build the image on first run."* The marketplace-installed flow must not require a repo clone, so the build step moves off `scripts/build-image.sh` (a clone-only tool) and into the skill itself.
+
+**Current behavior.** `commands/pal-setup.md` is a guide — it *describes* steps for the user to run, including `docker pull claude-pal:latest (or build locally from image/)`. The skill executes nothing.
+
+**New behavior.** The skill, in addition to walking the user through env-var setup, checks whether `claude-pal:latest` exists on the local Docker daemon. If absent, it offers to build it and on confirmation runs:
+
+```bash
+docker build \
+  --build-arg BASE_IMAGE="${BASE_IMAGE:-ubuntu:24.04}" \
+  -f "${CLAUDE_PLUGIN_ROOT}/image/Dockerfile" \
+  -t claude-pal:latest \
+  "${CLAUDE_PLUGIN_ROOT}"
+```
+
+This matches what `scripts/build-image.sh` does today; the skill just calls `docker build` directly rather than sourcing the script, because:
+- `${CLAUDE_PLUGIN_ROOT}` is the single source of truth for path resolution in this codebase (see `CLAUDE.md`).
+- Keeping the build inline avoids the skill having to locate and exec a sub-script, which is unnecessary indirection for a four-line command.
+
+`scripts/build-image.sh` remains in the repo unchanged — still the contributor / CI entry point when invoked from a clone.
+
+**Interaction boundary.** The skill should detect image presence with `docker image inspect claude-pal:latest >/dev/null 2>&1` and only trigger the build path when that fails. If Docker isn't reachable, the skill surfaces the error verbatim (no silent retry). If the build itself fails, likewise — the user sees `docker build` output and decides what to do.
+
+**Scope.** Image tag remains `claude-pal:latest`; no `--tag` flag exposed to users. Version-stamped image tags are future scope (related to #18 registry work).
+
 ## Documentation updates
 
 ### `docs/install.md`
@@ -91,11 +117,13 @@ Current file leads with `git clone` + `claude --plugin-dir ~/repos/claude-pal`. 
    /plugin marketplace add jnurre64/claude-pal
    /plugin install claude-pal@claude-pal
    ```
-2. Build (or pull) the container image — unchanged content, but revisit the example path since `./scripts/build-image.sh` assumes a clone. The implementation plan will decide between (a) running the script from its cached plugin location, (b) folding the build into `/pal-setup`, or (c) keeping the clone step as a prerequisite for image build only. This spec does not prescribe the choice — it's a secondary docs decision that should not block the marketplace work.
-3. Export `GH_TOKEN` — unchanged.
-4. `/pal-setup` then `/pal-login` — unchanged.
+2. **Export `GH_TOKEN`** — unchanged.
+3. **Run `/pal-setup`** — the skill checks whether the `claude-pal:latest` image exists on the local Docker daemon and, if not, builds it from `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile` with `${CLAUDE_PLUGIN_ROOT}` as the build context. No separate `build-image.sh` step in the end-user flow.
+4. **Run `/pal-login`** — unchanged.
 
-A new **"Contributor / local dev loop"** section at the end of the file retains the existing `claude plugin validate ~/repos/claude-pal` + `claude --plugin-dir ~/repos/claude-pal` content, for maintainers and PR contributors.
+`scripts/build-image.sh` stays in the repo as the contributor-facing entry point (invoked from the clone, used by CI and local dev loops); it is no longer surfaced in `docs/install.md`'s main "Install steps" section.
+
+A new **"Contributor / local dev loop"** section at the end of the file retains the existing `claude plugin validate ~/repos/claude-pal` + `claude --plugin-dir ~/repos/claude-pal` content plus the direct `./scripts/build-image.sh` invocation, for maintainers and PR contributors.
 
 ### `README.md`
 
@@ -106,7 +134,7 @@ Two sections need touch-ups:
   /plugin marketplace add jnurre64/claude-pal
   /plugin install claude-pal@claude-pal
   ```
-- **`One-time setup`** currently opens with `docker pull claude-pal:latest`. Prepend the marketplace install as step 0 so the ordering becomes: add marketplace → pull/build image → `/pal-setup` → `/pal-login`.
+- **`One-time setup`** currently opens with `docker pull claude-pal:latest`. Replace with the aligned flow: add marketplace → export `GH_TOKEN` → `/pal-setup` (which builds the image if absent) → `/pal-login`. No explicit `docker pull` / `build-image.sh` step in the end-user story.
 
 ### Release runbook
 

--- a/docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md
@@ -38,21 +38,26 @@ Self-hosted marketplace: the `jnurre64/claude-pal` repo hosts both the plugin *a
   "plugins": [
     {
       "name": "claude-pal",
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "jnurre64/claude-pal",
+        "ref": "v<next>"
+      },
       "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside a long-running Docker workspace container.",
       "homepage": "https://github.com/jnurre64/claude-pal",
-      "category": "automation",
-      "ref": "v<next>"
+      "category": "automation"
     }
   ]
 }
 ```
 
 **Field notes:**
-- `description` mirrors `plugin.json`'s `description` (updated here to reflect the current workspace-container model, which the stale `plugin.json` description does not fully capture).
+- `source` is a GitHub-source *object* (`{source: "github", repo, ref}`), not a path string. During initial discovery the spec assumed `source: "./"` + a top-level `ref`, but the Claude Code validator rejects top-level `ref` on plugin entries; the GitHub-source form is the schema-correct way to express "pin this plugin to tag X of repo Y." Verified with `claude plugin validate .`.
+- `description` mirrors `plugin.json`'s `description` (updated to reflect the current workspace-container model).
 - `homepage` and `category` are cheap metadata that improve the `/plugin` listing UX.
 - `icon` is intentionally omitted — binary-path handling adds friction we don't need today.
-- `ref` is a literal tag name (e.g. `"v0.5.0"`). Filled in at release time (see runbook).
+- `ref` (inside `source`) is a literal tag name (e.g. `"v0.5.0"`). Filled in at release time (see runbook).
+- During feature work the `ref` may temporarily be `"main"` so the manifest is valid without an unreleased tag; the release commit flips it to the target tag.
 
 ## Update model
 

--- a/docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md
+++ b/docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md
@@ -1,0 +1,175 @@
+# claude-pal Plugin Marketplace — Design
+
+**Status:** Approved 2026-04-23
+**Issue:** [#19 — Distribute claude-pal via self-hosted GitHub plugin marketplace](https://github.com/jnurre64/claude-pal/issues/19)
+**Supersedes:** —
+
+## Goal
+
+Make `jnurre64/claude-pal` a self-hosted Claude Code plugin marketplace so end-users can install claude-pal with a one-time `/plugin marketplace add jnurre64/claude-pal` + `/plugin install claude-pal@claude-pal`, replacing the session-scoped `claude --plugin-dir ~/repos/claude-pal` flow.
+
+Users never need to clone the repo. The plugin persists across Claude Code sessions. Updates arrive when we cut a new release and bump the manifest's `ref`.
+
+## Non-goals
+
+- Prebuilt container image distribution (tracked in [#18](https://github.com/jnurre64/claude-pal/issues/18)). `/pal-setup` continues to build the image on first run.
+- CI automation for `marketplace.json` `ref` bumping. Manual for v1; can be added later.
+- Multi-plugin repo layout. The flat, single-plugin layout is intentional — revisit only if a second plugin is added to the repo.
+- Version bump itself. Whether/when to cut `v0.5.0` (or `v0.6.0`, etc.) is out of scope for this issue; the release runbook below describes the mechanical step but does not prescribe the number.
+
+## Architecture
+
+Self-hosted marketplace: the `jnurre64/claude-pal` repo hosts both the plugin *and* its `marketplace.json`.
+
+**Layout — flat.** The repo already uses `.claude-plugin/plugin.json` at its existing location. The marketplace manifest joins it as `.claude-plugin/marketplace.json`, with the plugin entry's `source` set to `"./"` (the repo root, which is where `plugin.json` lives).
+
+**Rationale.** Flat is the prevailing convention when a repo hosts exactly one plugin (e.g. `obra/superpowers`). Nested `plugins/<name>/` layouts (e.g. `anthropics/claude-code`) only exist because those repos host multiple plugins. Adopting nesting preemptively would add path indirection without benefit.
+
+**Distribution path.** `/plugin marketplace add jnurre64/claude-pal` — Claude Code clones into a managed cache at `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`. `${CLAUDE_PLUGIN_ROOT}` resolves from the cached copy, so the repo's existing `lib/` sourcing pattern (`. "${CLAUDE_PLUGIN_ROOT}/lib/*.sh"`) keeps working unchanged.
+
+**Security model.** Trust-on-first-use, no signature verification — same as every GitHub-hosted marketplace. Public repo, so no `GH_TOKEN` bootstrap problem.
+
+## marketplace.json
+
+```json
+{
+  "name": "claude-pal",
+  "owner": { "name": "jnurre64" },
+  "plugins": [
+    {
+      "name": "claude-pal",
+      "source": "./",
+      "description": "Local agent dispatch for Claude Code — publishes implementation plans to GitHub and runs a gated pipeline (adversarial plan review → TDD implement → post-impl review → PR) inside a long-running Docker workspace container.",
+      "homepage": "https://github.com/jnurre64/claude-pal",
+      "category": "automation",
+      "ref": "v<next>"
+    }
+  ]
+}
+```
+
+**Field notes:**
+- `description` mirrors `plugin.json`'s `description` (updated here to reflect the current workspace-container model, which the stale `plugin.json` description does not fully capture).
+- `homepage` and `category` are cheap metadata that improve the `/plugin` listing UX.
+- `icon` is intentionally omitted — binary-path handling adds friction we don't need today.
+- `ref` is a literal tag name (e.g. `"v0.5.0"`). Filled in at release time (see runbook).
+
+## Update model
+
+**Model A: pin to latest release tag, bump manifest per release.** Chosen over the alternatives considered in issue #19:
+
+- **(A) Pin `ref` to tag — chosen.** Dominant real-world pattern. Users get predictable updates only when a release is cut. Requires bumping `marketplace.json`'s `ref` on each release. Manual for v1.
+- **(B) Track `main`.** Simpler for us, less predictable for users (updates arrive whenever a merge lands). Rejected.
+- **(C) Two entries — stable tag + `dev` on `main`.** Best UX, most maintenance overhead. Overkill at current scale.
+
+`/plugin marketplace update` re-reads the marketplace manifest. Because our entries are `ref`-pinned to a tag, installed plugins move only when the manifest's `ref` changes — i.e., on release.
+
+## Release sequencing
+
+**Option A: one PR, tag after merge.**
+
+1. Feature branch: add `.claude-plugin/marketplace.json`, rewrite docs, commit.
+2. Final commit on the branch bumps:
+   - `plugin.json` `version` → target release version.
+   - `marketplace.json` `plugins[0].ref` → target tag name (e.g. `"v0.5.0"`).
+3. Merge PR into `main`.
+4. Tag the merge commit with the target version: `git tag v<next> <merge-sha> && git push origin v<next>`.
+5. Create a GitHub release from the tag (optional but recommended for changelog visibility).
+
+There is a seconds-long window between PR merge and tag push where `main`'s `marketplace.json` references an unpushed tag. If a user adds the marketplace during that window they'll see a resolution failure. Acceptable; mitigated by keeping the tag push immediately after the merge.
+
+Rejected alternative: a two-phase approach (land marketplace.json first with `ref: "v0.4.0"` as a placeholder, cut the real tag later) was considered and rejected. `v0.4.0` predates the workspace-container rework and would give any interim installer a broken build.
+
+## Documentation updates
+
+### `docs/install.md`
+
+Current file leads with `git clone` + `claude --plugin-dir ~/repos/claude-pal`. Rewrite so **"Install steps"** becomes:
+
+1. **Install the Claude Code plugin** — the new marketplace recipe:
+   ```
+   /plugin marketplace add jnurre64/claude-pal
+   /plugin install claude-pal@claude-pal
+   ```
+2. Build (or pull) the container image — unchanged content, but revisit the example path since `./scripts/build-image.sh` assumes a clone. The implementation plan will decide between (a) running the script from its cached plugin location, (b) folding the build into `/pal-setup`, or (c) keeping the clone step as a prerequisite for image build only. This spec does not prescribe the choice — it's a secondary docs decision that should not block the marketplace work.
+3. Export `GH_TOKEN` — unchanged.
+4. `/pal-setup` then `/pal-login` — unchanged.
+
+A new **"Contributor / local dev loop"** section at the end of the file retains the existing `claude plugin validate ~/repos/claude-pal` + `claude --plugin-dir ~/repos/claude-pal` content, for maintainers and PR contributors.
+
+### `README.md`
+
+Two sections need touch-ups:
+
+- **`Getting started`** currently points at `docs/install.md` — keep that pointer but add a one-line install snippet above it:
+  ```
+  /plugin marketplace add jnurre64/claude-pal
+  /plugin install claude-pal@claude-pal
+  ```
+- **`One-time setup`** currently opens with `docker pull claude-pal:latest`. Prepend the marketplace install as step 0 so the ordering becomes: add marketplace → pull/build image → `/pal-setup` → `/pal-login`.
+
+### Release runbook
+
+A short **"Releasing"** section in this spec (below) captures the release mechanics. No separate `RELEASING.md`. If the runbook grows past what fits in a spec, split it later.
+
+## Smoke test (manual, pre-tag)
+
+Run on a clean Claude Code config before pushing the release tag:
+
+```bash
+CLAUDE_CONFIG_DIR=$(mktemp -d) claude
+```
+
+Inside the session:
+
+1. `/plugin marketplace add jnurre64/claude-pal` — confirm no errors.
+2. `/plugin install claude-pal@claude-pal` — confirm install succeeds.
+3. `/plugin` — confirm `claude-pal` appears in the listed plugins.
+4. `/skills` — confirm `pal-*` skills are present.
+5. `/claude-pal:pal-setup` — confirm the workspace container boots and credentials can be minted.
+
+Not wired into CI. Automation of this loop is deferred.
+
+## Releasing (runbook)
+
+Once per release:
+
+1. Update `CHANGELOG.md` with the version's entry.
+2. Edit `.claude-plugin/plugin.json` — bump `version`.
+3. Edit `.claude-plugin/marketplace.json` — set `plugins[0].ref` to the new tag name (e.g. `"v0.5.0"`).
+4. Commit: `chore(release): v<next>`.
+5. Open PR, merge to `main`.
+6. Tag the merge commit: `git tag v<next> <sha> && git push origin v<next>`.
+7. Optional: `gh release create v<next> --notes-from-tag` or write release notes by hand.
+8. Run the smoke test against the freshly-tagged release.
+
+Steps 2 and 3 must stay in lockstep: if `plugin.json` claims a version the marketplace manifest doesn't point at, `/plugin marketplace update` won't pick up the change cleanly.
+
+## Pitfalls
+
+- **Cache-only resolution.** Files outside the plugin root (i.e. outside the directory named by `source`) don't make it into the Claude Code cache. The claude-pal repo keeps all runtime files under the root already, but the spec mandates a grep sweep for any `../` references before release (verified clean at spec time — only hits are in vendored bats test fixtures under `tests/bats/`, which aren't in the runtime path).
+- **Private repos.** Not applicable to this repo (public), but note in docs that any user who forks to private would need `GH_TOKEN` set for `/plugin marketplace add` to succeed.
+- **User-global state.** The marketplace list lives in `~/.claude/plugins/known_marketplaces.json`, not per-project — all Claude Code sessions on a host share it. Users uninstall via `/plugin marketplace remove claude-pal`. Worth one line in docs.
+
+## Test plan
+
+**Unit / CI:** none new. `shellcheck` and BATS-Core continue to cover the existing shell surface. `marketplace.json` is a static JSON file — a `jq . .claude-plugin/marketplace.json` check can slot into CI as a cheap parse-validity guard if desired (included in the implementation plan as a nice-to-have).
+
+**Manual pre-release:** the smoke test recipe in the "Smoke test" section above.
+
+**Manual post-release:** on another clean host, repeat `/plugin marketplace add jnurre64/claude-pal` to confirm the published tag resolves.
+
+## Open questions
+
+None. The two open questions raised in issue #19 have been resolved:
+
+- *Automate `marketplace.json` ref bumping?* → Manual for v1.
+- *Tag `v0.5.0` now?* → Out of scope; the version bump happens at release time and is not prescribed by this spec.
+
+## Sources
+
+- [Plugin marketplaces — code.claude.com](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Discover and install plugins — code.claude.com](https://code.claude.com/docs/en/discover-plugins)
+- [Plugins reference — code.claude.com](https://code.claude.com/docs/en/plugins-reference)
+- [`obra/superpowers-marketplace`](https://github.com/obra/superpowers-marketplace)
+- [`anthropics/claude-code` marketplace.json](https://github.com/anthropics/claude-code/blob/main/.claude-plugin/marketplace.json)

--- a/lib/image.sh
+++ b/lib/image.sh
@@ -1,0 +1,9 @@
+# lib/image.sh
+# shellcheck shell=bash
+# Host-side helpers for the claude-pal container image.
+
+: "${PAL_WORKSPACE_IMAGE:=claude-pal:latest}"
+
+pal_image_exists() {
+    docker image inspect "$PAL_WORKSPACE_IMAGE" >/dev/null 2>&1
+}

--- a/lib/image.sh
+++ b/lib/image.sh
@@ -16,3 +16,11 @@ pal_image_build() {
         -t "$PAL_WORKSPACE_IMAGE" \
         "${CLAUDE_PLUGIN_ROOT}"
 }
+
+pal_image_ensure() {
+    if pal_image_exists; then
+        return 0
+    fi
+    echo "pal: building ${PAL_WORKSPACE_IMAGE}…" >&2
+    pal_image_build
+}

--- a/lib/image.sh
+++ b/lib/image.sh
@@ -7,3 +7,12 @@
 pal_image_exists() {
     docker image inspect "$PAL_WORKSPACE_IMAGE" >/dev/null 2>&1
 }
+
+pal_image_build() {
+    local base_image="${BASE_IMAGE:-ubuntu:24.04}"
+    docker build \
+        --build-arg BASE_IMAGE="$base_image" \
+        -f "${CLAUDE_PLUGIN_ROOT}/image/Dockerfile" \
+        -t "$PAL_WORKSPACE_IMAGE" \
+        "${CLAUDE_PLUGIN_ROOT}"
+}

--- a/tests/test_fake_docker_shim.bats
+++ b/tests/test_fake_docker_shim.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/fake-docker.sh'
+
+setup() { fake_docker_setup; }
+teardown() { fake_docker_teardown; }
+
+@test "fake docker: 'image inspect' fails when image not registered" {
+    run docker image inspect claude-pal:latest
+    assert_failure
+}
+
+@test "fake docker: 'image inspect' succeeds after fake_docker_set_image_exists" {
+    fake_docker_set_image_exists claude-pal:latest
+    run docker image inspect claude-pal:latest
+    assert_success
+}
+
+@test "fake docker: 'build' is recorded in FAKE_DOCKER_LOG" {
+    run docker build -t claude-pal:latest -f some/Dockerfile .
+    assert_success
+    run grep -F "build -t claude-pal:latest" "$FAKE_DOCKER_LOG"
+    assert_success
+}

--- a/tests/test_fake_docker_shim.bats
+++ b/tests/test_fake_docker_shim.bats
@@ -25,3 +25,12 @@ teardown() { fake_docker_teardown; }
     run grep -F "build -t claude-pal:latest" "$FAKE_DOCKER_LOG"
     assert_success
 }
+
+@test "fake docker: 'image inspect' handles slashed registry tags round-trip" {
+    fake_docker_set_image_exists myregistry.io/org/image:latest
+    run docker image inspect myregistry.io/org/image:latest
+    assert_success
+    fake_docker_set_image_absent myregistry.io/org/image:latest
+    run docker image inspect myregistry.io/org/image:latest
+    assert_failure
+}

--- a/tests/test_helper/fake-docker.sh
+++ b/tests/test_helper/fake-docker.sh
@@ -42,6 +42,21 @@ case "$1" in
         fi
         exit 1
         ;;
+    image)
+        # Handle `docker image inspect <tag>` — success only if the tag is
+        # marked present via fake_docker_set_image_exists.
+        if [ "${2:-}" = "inspect" ] && [ -n "${3:-}" ]; then
+            if [ -f "$FAKE_DOCKER_STATE/image_${3//:/_}" ]; then
+                echo '[{"Id":"fake"}]'
+                exit 0
+            fi
+            exit 1
+        fi
+        # Any other `docker image <subcommand>` — default success.
+        ;;
+    build)
+        # Already logged at top of shim; default success. Tests grep the log.
+        ;;
     exec)
         # Last arg is usually the command; simulate success by default.
         if [ -f "$FAKE_DOCKER_STATE/exec_fails" ]; then
@@ -89,4 +104,14 @@ fake_docker_set_stopped() {
 
 fake_docker_set_absent() {
     rm -f "$FAKE_DOCKER_STATE/running" "$FAKE_DOCKER_STATE/exists"
+}
+
+fake_docker_set_image_exists() {
+    local tag="${1:-claude-pal:latest}"
+    : > "$FAKE_DOCKER_STATE/image_${tag//:/_}"
+}
+
+fake_docker_set_image_absent() {
+    local tag="${1:-claude-pal:latest}"
+    rm -f "$FAKE_DOCKER_STATE/image_${tag//:/_}"
 }

--- a/tests/test_helper/fake-docker.sh
+++ b/tests/test_helper/fake-docker.sh
@@ -46,7 +46,9 @@ case "$1" in
         # Handle `docker image inspect <tag>` — success only if the tag is
         # marked present via fake_docker_set_image_exists.
         if [ "${2:-}" = "inspect" ] && [ -n "${3:-}" ]; then
-            if [ -f "$FAKE_DOCKER_STATE/image_${3//:/_}" ]; then
+            safe_tag="${3//:/_}"
+            safe_tag="${safe_tag//\//_}"
+            if [ -f "$FAKE_DOCKER_STATE/image_${safe_tag}" ]; then
                 echo '[{"Id":"fake"}]'
                 exit 0
             fi
@@ -108,10 +110,14 @@ fake_docker_set_absent() {
 
 fake_docker_set_image_exists() {
     local tag="${1:-claude-pal:latest}"
-    : > "$FAKE_DOCKER_STATE/image_${tag//:/_}"
+    local safe_tag="${tag//:/_}"
+    safe_tag="${safe_tag//\//_}"
+    : > "$FAKE_DOCKER_STATE/image_${safe_tag}"
 }
 
 fake_docker_set_image_absent() {
     local tag="${1:-claude-pal:latest}"
-    rm -f "$FAKE_DOCKER_STATE/image_${tag//:/_}"
+    local safe_tag="${tag//:/_}"
+    safe_tag="${safe_tag//\//_}"
+    rm -f "$FAKE_DOCKER_STATE/image_${safe_tag}"
 }

--- a/tests/test_image.bats
+++ b/tests/test_image.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+load 'test_helper/fake-docker.sh'
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export CLAUDE_PLUGIN_ROOT="$REPO_ROOT"
+    fake_docker_setup
+    # shellcheck source=../lib/image.sh
+    . "$REPO_ROOT/lib/image.sh"
+}
+
+teardown() {
+    fake_docker_teardown
+}
+
+@test "pal_image_exists: returns success when image is present" {
+    fake_docker_set_image_exists claude-pal:latest
+    run pal_image_exists
+    assert_success
+}
+
+@test "pal_image_exists: returns failure when image is absent" {
+    fake_docker_set_image_absent claude-pal:latest
+    run pal_image_exists
+    assert_failure
+}
+
+@test "pal_image_exists: uses PAL_WORKSPACE_IMAGE override" {
+    fake_docker_set_image_exists claude-pal:v0.5.0
+    PAL_WORKSPACE_IMAGE=claude-pal:v0.5.0 run pal_image_exists
+    assert_success
+}

--- a/tests/test_image.bats
+++ b/tests/test_image.bats
@@ -34,3 +34,36 @@ teardown() {
     PAL_WORKSPACE_IMAGE=claude-pal:v0.5.0 run pal_image_exists
     assert_success
 }
+
+@test "pal_image_build: invokes docker build with Dockerfile and plugin root as context" {
+    run pal_image_build
+    assert_success
+    run grep -F -- "-f ${CLAUDE_PLUGIN_ROOT}/image/Dockerfile" "$FAKE_DOCKER_LOG"
+    assert_success
+    run grep -F -- "-t claude-pal:latest" "$FAKE_DOCKER_LOG"
+    assert_success
+    # Build context is the plugin root (trailing positional).
+    run grep -F -- "${CLAUDE_PLUGIN_ROOT}" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_build: passes BASE_IMAGE build-arg (default ubuntu:24.04)" {
+    run pal_image_build
+    assert_success
+    run grep -F -- "--build-arg BASE_IMAGE=ubuntu:24.04" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_build: respects BASE_IMAGE env override" {
+    BASE_IMAGE=ubuntu:22.04 run pal_image_build
+    assert_success
+    run grep -F -- "--build-arg BASE_IMAGE=ubuntu:22.04" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_build: respects PAL_WORKSPACE_IMAGE tag override" {
+    PAL_WORKSPACE_IMAGE=claude-pal:v0.5.0 run pal_image_build
+    assert_success
+    run grep -F -- "-t claude-pal:v0.5.0" "$FAKE_DOCKER_LOG"
+    assert_success
+}

--- a/tests/test_image.bats
+++ b/tests/test_image.bats
@@ -67,3 +67,26 @@ teardown() {
     run grep -F -- "-t claude-pal:v0.5.0" "$FAKE_DOCKER_LOG"
     assert_success
 }
+
+@test "pal_image_ensure: builds when image is absent" {
+    fake_docker_set_image_absent claude-pal:latest
+    run pal_image_ensure
+    assert_success
+    run grep -F "build" "$FAKE_DOCKER_LOG"
+    assert_success
+}
+
+@test "pal_image_ensure: does NOT build when image is already present" {
+    fake_docker_set_image_exists claude-pal:latest
+    run pal_image_ensure
+    assert_success
+    run grep -F "build" "$FAKE_DOCKER_LOG"
+    assert_failure
+}
+
+@test "pal_image_ensure: prints progress note when building" {
+    fake_docker_set_image_absent claude-pal:latest
+    run pal_image_ensure
+    assert_success
+    assert_output --partial "pal: building claude-pal:latest"
+}


### PR DESCRIPTION
Closes #19.

**Spec:** `docs/superpowers/specs/2026-04-23-plugin-marketplace-design.md`
**Plan:** `docs/superpowers/plans/2026-04-23-plugin-marketplace.md`

## Summary

- Add `.claude-plugin/marketplace.json` (flat layout, single plugin entry) so end-users can install claude-pal with `/plugin marketplace add jnurre64/claude-pal` + `/plugin install claude-pal@claude-pal` instead of the session-scoped `claude --plugin-dir` recipe.
- `/pal-setup` now auto-builds `claude-pal:latest` via new `lib/image.sh` helpers (`pal_image_exists`, `pal_image_build`, `pal_image_ensure`) using `${CLAUDE_PLUGIN_ROOT}/image/Dockerfile` as the build context. The marketplace install flow no longer requires a repo clone.
- Rewrite `docs/install.md` and `README.md` for the marketplace flow; clone-based workflow moves to a "Contributor / local dev loop" section for maintainers.
- CI `jq -e` parse check for both `.claude-plugin/*.json` manifests.

## Schema note

Spec originally prescribed `source: "./"` + top-level `ref` on the plugin entry. The Claude Code validator rejects top-level `ref`; corrected inline to the schema-correct `source: {source: "github", repo, ref}` form. Spec + plan updated to match.

## Release sequencing (Model A, per spec)

During feature work `ref` is `"main"`. The final commit on this branch (the release-prep commit) will bump `plugin.json.version` and set `marketplace.json.plugins[0].source.ref` to the target tag. After merge, the tag is cut on the merge commit, then a post-merge smoke test against the tagged marketplace closes the loop.

## Test plan

- [x] BATS: `tests/test_image.bats` (10 tests) and `tests/test_fake_docker_shim.bats` (4 tests) added
- [x] Full BATS suite: 66/66 passing (up from 55 pre-feature)
- [x] `shellcheck` across all `*.sh` files: clean
- [x] `claude plugin validate .`: passes with zero warnings
- [x] `jq -e` parse on both manifests: ok
- [ ] Post-merge marketplace smoke test on clean `CLAUDE_CONFIG_DIR` (Task 12)
- [ ] Post-tag re-smoke to confirm tagged release resolves (Task 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)