### PR TITLE
docs: rename claude-pal-action → sandbox-pal-action in live refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ First dogfood-ready release. Ships the core flow from an ideation session to an 
 - **Auth: env-passthrough only** — reads `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) + `GH_TOKEN` from the process env, forwards to container at `docker run -e`. No on-disk secrets file. Matches Anthropic's `claude-code-action` pattern.
 - **Preflight checks** — auth present, single auth method, Docker reachable, Windows bash, `gh auth status`, no-double-dispatch lock
 - **Per-repo config** — `.pal/config.env` for non-secret project knobs (test commands, model overrides, allowlist extensions)
-- **Vendored review-gate library** — prompts + `review-gates.sh` from `jnurre64/claude-pal-action` (formerly `claude-agent-dispatch`); see `UPSTREAM.md`
+- **Vendored review-gate library** — prompts + `review-gates.sh` from `jnurre64/sandbox-pal-action` (formerly `claude-pal-action` / `claude-agent-dispatch`); see `UPSTREAM.md`
 
 ### Fixed
 - Launcher pre-creates log file as 0666 before `docker run` so the container's non-root `agent` user can append to it (host-owned file blocked writes)

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Claude credentials live in a Docker-managed named volume inside the workspace �
 
 Full walkthrough in [`docs/install.md`](docs/install.md).
 
-## Relationship to `claude-pal-action`
+## Relationship to `sandbox-pal-action`
 
-Sibling project. `claude-pal-action` (formerly `claude-agent-dispatch`) runs the same pipeline shape on self-hosted GitHub Actions runners for team / shared use. sandbox-pal is personal, local, and triggered from a Claude Code session rather than GitHub labels. sandbox-pal vendors the review-gate prompts and orchestration library from upstream — see `UPSTREAM.md`.
+Sibling project. `sandbox-pal-action` (formerly `claude-pal-action`, originally `claude-agent-dispatch`) runs the same pipeline shape on self-hosted GitHub Actions runners for team / shared use. sandbox-pal is personal, local, and triggered from a Claude Code session rather than GitHub labels. sandbox-pal vendors the review-gate prompts and orchestration library from upstream — see `UPSTREAM.md`.
 
 ## Authentication
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -22,7 +22,7 @@ Earlier drafts of sandbox-pal used env-passthrough — the host shell held a `CL
 - **Credentials never touch the host filesystem.** `.credentials.json` lives in the `sandbox-pal-claude` Docker volume; it never appears in `~/.bashrc`, `~/.zshrc`, or `~/.claude/` on the host.
 - **`claude setup-token` is eliminated** from user setup, which also removes the "paste a token into chat by accident" failure mode.
 
-If you specifically need non-interactive env-var auth (for example, a CI runner), use the sibling project [`claude-pal-action`](https://github.com/jnurre64/claude-pal-action) instead — it's designed for the shared-runner / GitHub Actions topology.
+If you specifically need non-interactive env-var auth (for example, a CI runner), use the sibling project [`sandbox-pal-action`](https://github.com/jnurre64/sandbox-pal-action) instead — it's designed for the shared-runner / GitHub Actions topology.
 
 ## Where credentials live
 
@@ -49,7 +49,7 @@ Hard "don't":
 - Do not share the workspace volume with other users or machines.
 - Do not expose the workspace container over the network.
 - Do not use someone else's Claude subscription to log in.
-- Do not deploy sandbox-pal as a shared service for a team — for commercial / multi-user scenarios, use a Console account (and still log in via `/pal-login` inside your own workspace on your own machine), or use `claude-pal-action` on a shared runner.
+- Do not deploy sandbox-pal as a shared service for a team — for commercial / multi-user scenarios, use a Console account (and still log in via `/pal-login` inside your own workspace on your own machine), or use `sandbox-pal-action` on a shared runner.
 
 ## Migration from env-var auth
 

--- a/docs/superpowers/specs/2026-04-19-oss-health-skill-design.md
+++ b/docs/superpowers/specs/2026-04-19-oss-health-skill-design.md
@@ -9,7 +9,7 @@
 
 ## Motivation
 
-Derived from a comparative audit of `jnurre64/claude-pal-action` (strong open source hygiene baseline) and `jnurre64/sandbox-pal` (missing several standard GitHub community health files and CI/CD automation). The skill encodes the findings as a reusable checklist so any repo can be brought to the same standard.
+Derived from a comparative audit of `jnurre64/sandbox-pal-action` (strong open source hygiene baseline) and `jnurre64/sandbox-pal` (missing several standard GitHub community health files and CI/CD automation). The skill encodes the findings as a reusable checklist so any repo can be brought to the same standard.
 
 ## Architecture
 
@@ -151,7 +151,7 @@ After reporting each gap the skill asks "Fix this now?" before writing anything.
 
 ## Baseline Reference
 
-The checklist items and templates are calibrated against the practices found in `jnurre64/claude-pal-action`, which serves as the reference implementation for this skill's "healthy" baseline. When generating scaffolded files, match the style and conventions of that repo unless the target repo has its own established conventions.
+The checklist items and templates are calibrated against the practices found in `jnurre64/sandbox-pal-action`, which serves as the reference implementation for this skill's "healthy" baseline. When generating scaffolded files, match the style and conventions of that repo unless the target repo has its own established conventions.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

The sibling repo `jnurre64/claude-pal-action` was renamed to `jnurre64/sandbox-pal-action` on GitHub. Update the four live docs that still pointed at the old name.

## Changes

- `README.md` — "Relationship to" section heading + body now say `sandbox-pal-action`; chained the historical "formerly" trail
- `docs/authentication.md` — both sibling-project mentions updated (link target on line 25 and prose on line 52)
- `CHANGELOG.md` — 0.4.0 vendoring entry updated to `jnurre64/sandbox-pal-action` so the URL resolves directly without GitHub redirect
- `docs/superpowers/specs/2026-04-19-oss-health-skill-design.md` — both baseline-reference mentions for the oss-health skill

## Intentionally left alone

- `CHANGELOG.md` Unreleased migration block (lines 6–33) — must reference orphaned `claude-pal-*` state to instruct migrating users
- `docs/superpowers/plans/2026-04-23-rename-to-sandbox-pal.md`, `specs/2026-04-23-rename-to-sandbox-pal-design.md`, `plans/2026-04-23-plugin-marketplace.md`, `plans/2026-04-18-sandbox-pal.md`, `plans/2026-04-18-claude-pal.md` — frozen plan/spec records that document past state; the embedded README snippet on `2026-04-18-sandbox-pal.md` lines 3800/3802/3838 captures what the plan instructed at the time

## Testing

Doc-only change — no `*.sh` / `tests/` files modified, so `shellcheck` and `bats` are unaffected.

- [x] `shellcheck` — N/A (no shell changes)
- [x] `bats tests/` — N/A (no test or production-code changes)
- [x] Verified post-edit `grep -rn 'claude-pal' --exclude-dir=.git .` returns only the intentional historical refs listed above

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)