### PR TITLE
docs(readme): drop historical "formerly" trail from sibling-project line

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Full walkthrough in [`docs/install.md`](docs/install.md).
 
 ## Relationship to `sandbox-pal-action`
 
-Sibling project. `sandbox-pal-action` (formerly `claude-pal-action`, originally `claude-agent-dispatch`) runs the same pipeline shape on self-hosted GitHub Actions runners for team / shared use. sandbox-pal is personal, local, and triggered from a Claude Code session rather than GitHub labels. sandbox-pal vendors the review-gate prompts and orchestration library from upstream — see `UPSTREAM.md`.
+Sibling project. `sandbox-pal-action` runs the same pipeline shape on self-hosted GitHub Actions runners for team / shared use. sandbox-pal is personal, local, and triggered from a Claude Code session rather than GitHub labels. sandbox-pal vendors the review-gate prompts and orchestration library from upstream — see `UPSTREAM.md`.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

Drop the chained rename history from the sibling-project line in the README. Both renames (`claude-agent-dispatch` → `claude-pal-action` → `sandbox-pal-action`) are now merged and no longer useful context for new readers.

## Changes

- `README.md` line 46 — remove `(formerly \`claude-pal-action\`, originally \`claude-agent-dispatch\`)` parenthetical

## Testing

- [x] `shellcheck` — N/A (no shell changes)
- [x] `bats tests/` — N/A (no test or production-code changes)

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)